### PR TITLE
Add clear button with callback to autosuggest input

### DIFF
--- a/css/react-seda-search.css
+++ b/css/react-seda-search.css
@@ -69,11 +69,7 @@
   background-color: #ddd;
 }
 
-.react-autosuggest-container {
-  position: relative;
-}
-
-button.clear {
+.react-autosuggest__clear {
   cursor: pointer;
   border-color: transparent;
   border-width: 0;

--- a/css/react-seda-search.css
+++ b/css/react-seda-search.css
@@ -68,3 +68,20 @@
 .react-autosuggest__suggestion--highlighted {
   background-color: #ddd;
 }
+
+.react-autosuggest-container {
+  position: relative;
+}
+
+button.clear {
+  cursor: pointer;
+  border-color: transparent;
+  border-width: 0;
+  position: absolute;
+  top: 3px;
+  right: 10px;
+  height: 40px;
+  font-size: 40px;
+  line-height: 20px;
+  color: #aaa;
+}

--- a/demo/src/index.html
+++ b/demo/src/index.html
@@ -85,7 +85,7 @@
         position: relative;
       }
 
-      button.clear {
+      .react-autosuggest__clear {
         cursor: pointer;
         border-color: transparent;
         border-width: 0;
@@ -97,6 +97,7 @@
         line-height: 20px;
         color: #aaa;
       }
+
     </style>
   </head>
   <body>

--- a/demo/src/index.html
+++ b/demo/src/index.html
@@ -81,6 +81,22 @@
         background-color: #ddd;
       }
 
+      .react-autosuggest-container {
+        position: relative;
+      }
+
+      button.clear {
+        cursor: pointer;
+        border-color: transparent;
+        border-width: 0;
+        position: absolute;
+        top: 3px;
+        right: 10px;
+        height: 40px;
+        font-size: 40px;
+        line-height: 20px;
+        color: #aaa;
+      }
     </style>
   </head>
   <body>

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -11,6 +11,7 @@ class Demo extends Component {
         algoliaId='QPJ12WSVR4'
         algoliaKey='bae9e4604dbd263cc47c48bfb30dd5dc'
         onSuggestionSelected={console.log}
+        onSelectedClear={ console.log }
         indices={['cities', 'counties', 'districts', 'schools']}
         inputProps={{
           placeholder: 'Search seda data...'

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ class AutoComplete extends Component {
     currentRefinement: PropTypes.string.isRequired,
     refine: PropTypes.func.isRequired,
     onSuggestionSelected: PropTypes.func.isRequired,
+    onSelectedClear: PropTypes.func.isRequired,
   };
 
   state = {
@@ -30,6 +31,13 @@ class AutoComplete extends Component {
   onSuggestionsClearRequested = () => {
     this.props.refine();
   };
+
+  handleSelectedClear = () => {
+    this.setState({
+      value: '',
+    });
+    this.props.onSelectedClear();
+  }
 
   getSuggestionValue(hit) {
     return hit.name;
@@ -66,18 +74,21 @@ class AutoComplete extends Component {
     };
 
     return (
-      <AutoSuggest
-        suggestions={hits}
-        multiSection={multiSection}
-        onSuggestionsFetchRequested={this.onSuggestionsFetchRequested}
-        onSuggestionsClearRequested={this.onSuggestionsClearRequested}
-        onSuggestionSelected={onSuggestionSelected}
-        getSuggestionValue={this.getSuggestionValue}
-        renderSuggestion={this.renderSuggestion}
-        inputProps={inputProps}
-        renderSectionTitle={this.renderSectionTitle}
-        getSectionSuggestions={this.getSectionSuggestions}
-      />
+      <div className="react-autosuggest-container">
+        <AutoSuggest
+          suggestions={hits}
+          multiSection={multiSection}
+          onSuggestionsFetchRequested={this.onSuggestionsFetchRequested}
+          onSuggestionsClearRequested={this.onSuggestionsClearRequested}
+          onSuggestionSelected={onSuggestionSelected}
+          getSuggestionValue={this.getSuggestionValue}
+          renderSuggestion={this.renderSuggestion}
+          inputProps={inputProps}
+          renderSectionTitle={this.renderSectionTitle}
+          getSectionSuggestions={this.getSectionSuggestions}
+        />
+        <button className="clear" onClick={this.handleSelectedClear}>&times;</button>
+      </div>
     );
   }
 }
@@ -90,7 +101,8 @@ const SedaSearch = ({
   algoliaKey, 
   indices = [], 
   inputProps,
-  onSuggestionSelected
+  onSuggestionSelected,
+  onSelectedClear
 }) => {
   const searchClient = useMemo(() => {
     let client = false;
@@ -127,6 +139,9 @@ const SedaSearch = ({
           onSuggestionSelected={
             (e, { suggestion }) => onSuggestionSelected(suggestion)
           }
+          onSelectedClear={
+            () => onSelectedClear('Clearing input.')
+          }
         />
         {
           indices.map((index,i) =>
@@ -134,6 +149,7 @@ const SedaSearch = ({
           )
         }
       </InstantSearch>
+
       :
       <span>No indices for search</span>
   )

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,13 @@ import { Highlight, connectAutoComplete, InstantSearch, Index, Configure } from 
 import AutoSuggest from 'react-autosuggest';
 import algoliasearch from 'algoliasearch/lite';
 
+/** Renders the input component for search */
+const renderInputComponent = (inputProps, onClear) => (
+  <div className="react-autosuggest__input-wrapper">
+    <input {...inputProps} />
+    <button aria-label="clear search text" className="react-autosuggest__clear" onClick={onClear}>&times;</button>
+  </div>
+);
 
 class AutoComplete extends Component {
   static propTypes = {
@@ -74,21 +81,19 @@ class AutoComplete extends Component {
     };
 
     return (
-      <div className="react-autosuggest-container">
-        <AutoSuggest
-          suggestions={hits}
-          multiSection={multiSection}
-          onSuggestionsFetchRequested={this.onSuggestionsFetchRequested}
-          onSuggestionsClearRequested={this.onSuggestionsClearRequested}
-          onSuggestionSelected={onSuggestionSelected}
-          getSuggestionValue={this.getSuggestionValue}
-          renderSuggestion={this.renderSuggestion}
-          inputProps={inputProps}
-          renderSectionTitle={this.renderSectionTitle}
-          getSectionSuggestions={this.getSectionSuggestions}
-        />
-        <button className="clear" onClick={this.handleSelectedClear}>&times;</button>
-      </div>
+      <AutoSuggest
+        suggestions={hits}
+        multiSection={multiSection}
+        onSuggestionsFetchRequested={this.onSuggestionsFetchRequested}
+        onSuggestionsClearRequested={this.onSuggestionsClearRequested}
+        onSuggestionSelected={onSuggestionSelected}
+        getSuggestionValue={this.getSuggestionValue}
+        renderSuggestion={this.renderSuggestion}
+        inputProps={inputProps}
+        renderInputComponent={(inputProps) => renderInputComponent(inputProps, this.handleSelectedClear)}
+        renderSectionTitle={this.renderSectionTitle}
+        getSectionSuggestions={this.getSectionSuggestions}
+      />
     );
   }
 }


### PR DESCRIPTION
Hi @Lane , @james-minton requested that a "clear" button be added to the search component. I've created a pull request that adds a button. onClick both clears the current input value and sends a callback that I can use to clear the scatterplot search result and reload state. If this isn't according to spec or style parameters just let me know. I would be interested in any input you have. 